### PR TITLE
horizon: filter out X-Forwarded-* and EDNS0_SUBNET when forwarding isn't allowed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	darvaza.org/core v0.11.2
 	darvaza.org/darvaza/shared v0.5.11
 	darvaza.org/darvaza/shared/config v0.2.7
-	darvaza.org/resolver v0.7.18
+	darvaza.org/resolver v0.7.19
 	darvaza.org/sidecar v0.3.2
 	darvaza.org/sidecar/pkg/service v0.0.4
 	darvaza.org/slog v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ darvaza.org/darvaza/shared/web v0.3.11 h1:TshGAKWt9OTjWQq6oYjFF/KKN8hZ1eS5ApZJyc
 darvaza.org/darvaza/shared/web v0.3.11/go.mod h1:W56Im4j2kDfQfRDAQzxXhkitpt57pT7ZKlxZL+tokuM=
 darvaza.org/middleware v0.2.6 h1:CE9l236k/9FQsqMv1nhpUKgVJP1LLbixqzCvWuv1X2I=
 darvaza.org/middleware v0.2.6/go.mod h1:Dou0RzAi1beOlH9hXouGhQ2jKVWSfEzmGzZNEFMIWUE=
-darvaza.org/resolver v0.7.18 h1:sgMED2QwRxl+fEa+ndr+nxDu3VXhpQLptJG1aUXLJGY=
-darvaza.org/resolver v0.7.18/go.mod h1:ebLdfSWJwcCGy3iS5rAmsWFEXr3lkMWxX8K26zsOI/w=
+darvaza.org/resolver v0.7.19 h1:RomnRGuFHTUxPgy94t4Fu79mdNNcFwRq71/uAByvCgY=
+darvaza.org/resolver v0.7.19/go.mod h1:ebLdfSWJwcCGy3iS5rAmsWFEXr3lkMWxX8K26zsOI/w=
 darvaza.org/sidecar v0.3.2 h1:kPcNiz77m/p5eSk/PmW7BalokIx4VkTuKGf+/O5na5M=
 darvaza.org/sidecar v0.3.2/go.mod h1:Ai0hjbllX03mXP2be9KfMQx79SRbNjni1uolrtixmU8=
 darvaza.org/sidecar/pkg/service v0.0.4 h1:L6FHIdAemdQMGGzOUekKvkuvVIhwe+qBMt+ZsB1l0IU=

--- a/pkg/horizon/config.go
+++ b/pkg/horizon/config.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/netip"
 
+	"darvaza.org/core"
 	"darvaza.org/resolver"
 	"darvaza.org/sidecar/pkg/sidecar/horizon"
 )
@@ -20,12 +21,14 @@ type Config struct {
 }
 
 // New creates a new [Horizon] from the [Config]
-func (hc Config) New(next *Horizon, res resolver.Exchanger) (*Horizon, error) {
+func (hc Config) New(next *Horizon, res resolver.Exchanger,
+	ctxKey *core.ContextKey[horizon.Match]) (*Horizon, error) {
 	//
 	z := &Horizon{
 		next: next,
 		res:  res,
 
+		ctxKey:          ctxKey,
 		allowForwarding: hc.AllowForwarding,
 	}
 

--- a/pkg/horizon/config.go
+++ b/pkg/horizon/config.go
@@ -25,6 +25,8 @@ func (hc Config) New(next *Horizon, res resolver.Exchanger) (*Horizon, error) {
 	z := &Horizon{
 		next: next,
 		res:  res,
+
+		allowForwarding: hc.AllowForwarding,
 	}
 
 	z.zc = horizon.Config{

--- a/pkg/horizon/dns.go
+++ b/pkg/horizon/dns.go
@@ -57,17 +57,7 @@ func (z *Horizon) HorizonExchange(ctx context.Context, req *dns.Msg) (*dns.Msg, 
 	}
 
 	resp, err := z.Exchange(ctx, req)
-	switch {
-	case err != nil:
-		return nil, err
-	case req != original:
-		// restore ID
-		resp.Id = original.Id
-		return resp, nil
-	default:
-		// request unaltered
-		return resp, nil
-	}
+	return exdns.RestoreReturn(original, resp, err)
 }
 
 func (z *Horizon) replaceEDNS0SUBNET(ctx context.Context, req *dns.Msg) (*dns.Msg, bool) {

--- a/pkg/horizon/dns.go
+++ b/pkg/horizon/dns.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/miekg/dns"
 
+	"darvaza.org/core"
 	"darvaza.org/resolver"
 )
 
@@ -35,6 +36,67 @@ func (z *Horizon) Exchange(ctx context.Context, req *dns.Msg) (*dns.Msg, error) 
 // A Horizon that acts as entry point has to make sure security constraints
 // are checked.
 func (z *Horizon) HorizonExchange(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
-	// TODO: replace EDNS0 SUBNET when forwarding isn't allowed
-	return z.Exchange(ctx, req)
+	var original = req
+
+	if !z.allowForwarding {
+		req2 := req.Copy()
+
+		// remove EDNS0 SUBNET data
+		altered := removeEDNS0SUBNET(req2)
+
+		// TODO: inject new EDNS0 SUBNET based on the horizon.Match
+
+		if altered {
+			// new request
+			req2.Id = dns.Id()
+			req = req2
+		}
+	}
+
+	resp, err := z.Exchange(ctx, req)
+	switch {
+	case err != nil:
+		return nil, err
+	case req != original:
+		// restore ID
+		resp.Id = original.Id
+		return resp, nil
+	default:
+		// request unaltered
+		return resp, nil
+	}
+}
+
+func removeEDNS0SUBNET(req *dns.Msg) bool {
+	var altered bool
+
+	filterEDNS0 := func(_ []dns.EDNS0, e dns.EDNS0) (dns.EDNS0, bool) {
+		if e.Option() == dns.EDNS0SUBNET {
+			// discard
+			altered = true
+			return nil, false
+		}
+
+		// keep
+		return e, true
+	}
+
+	filterRR := func(_ []dns.RR, rr dns.RR) (dns.RR, bool) {
+		if opts, ok := rr.(*dns.OPT); ok {
+			// remove EDNS0SUBNET options
+			opts.Option = core.SliceReplaceFn(opts.Option, filterEDNS0)
+
+			if len(opts.Option) == 0 {
+				// empty RR, discard
+				altered = true
+				return nil, false
+			}
+		}
+
+		// keep
+		return rr, true
+	}
+
+	req.Extra = core.SliceReplaceFn(req.Extra, filterRR)
+	return altered
 }

--- a/pkg/horizon/horizon.go
+++ b/pkg/horizon/horizon.go
@@ -158,6 +158,8 @@ type Horizon struct {
 	res  resolver.Exchanger
 	zc   horizon.Config
 
+	allowForwarding bool
+
 	nextH http.Handler
 	nextE resolver.Exchanger
 }

--- a/pkg/horizon/horizon.go
+++ b/pkg/horizon/horizon.go
@@ -13,7 +13,8 @@ import (
 
 // MakeHorizons builds Horizons from a [Config] slice
 func MakeHorizons(conf []Config,
-	res map[string]resolver.Exchanger) ([]string, map[string]*Horizon, error) {
+	res map[string]resolver.Exchanger,
+	ctxKey *core.ContextKey[horizon.Match]) ([]string, map[string]*Horizon, error) {
 	//
 	names, m, err := makeHorizonsMap(conf)
 	if err != nil {
@@ -22,7 +23,7 @@ func MakeHorizons(conf []Config,
 
 	out := make(map[string]*Horizon)
 	for len(m) > 0 {
-		err := makeHorizonsPass(out, m, res)
+		err := makeHorizonsPass(out, m, res, ctxKey)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -32,7 +33,7 @@ func MakeHorizons(conf []Config,
 }
 
 func makeHorizonsPass(out map[string]*Horizon, conf map[string]Config,
-	res map[string]resolver.Exchanger) error {
+	res map[string]resolver.Exchanger, ctxKey *core.ContextKey[horizon.Match]) error {
 	//
 	name, next, err := nextMakeHorizons(out, conf)
 	if err != nil {
@@ -57,7 +58,7 @@ func makeHorizonsPass(out map[string]*Horizon, conf map[string]Config,
 		}
 	}
 
-	h, err := hc.New(next, r)
+	h, err := hc.New(next, r, ctxKey)
 	if err != nil {
 		// failed to build horizon
 		return err
@@ -154,9 +155,10 @@ func getMakeHorizonsResolver(name string,
 
 // A Horizon is a [resolver.Exchanger] for a particular set of networks
 type Horizon struct {
-	next *Horizon
-	res  resolver.Exchanger
-	zc   horizon.Config
+	next   *Horizon
+	ctxKey *core.ContextKey[horizon.Match]
+	res    resolver.Exchanger
+	zc     horizon.Config
 
 	allowForwarding bool
 

--- a/pkg/resolver/config.go
+++ b/pkg/resolver/config.go
@@ -15,6 +15,10 @@ type Config struct {
 	// Debug indicates the requests passing through this [Resolver] should be logged or not.
 	Debug bool `yaml:"debug,omitempty"        toml:",omitempty" json:",omitempty"`
 
+	// OmitSubNet indicates requests reaching out to remote servers should omit
+	// EDNS0 SUBNET information.
+	OmitSubNet bool `yaml:"omit_subnet,omitempty" toml:",omitempty" json:",omitempty"`
+
 	DisableAAAA bool     `yaml:"disable_aaaa,omitempty" toml:",omitempty" json:",omitempty"`
 	Iterative   bool     `yaml:"iterative,omitempty"    toml:",omitempty" json:",omitempty"`
 	Recursive   bool     `yaml:"recursive,omitempty"    toml:",omitempty" json:",omitempty"`

--- a/pkg/resolver/config_iterative.go
+++ b/pkg/resolver/config_iterative.go
@@ -36,6 +36,10 @@ func (rc Config) setupIterative(r *Resolver, opts *Options) error {
 
 	// TODO: add cache
 
+	if rc.OmitSubNet {
+		e = newOmitEDNS0SubNetExchanger(e)
+	}
+
 	if rc.Debug {
 		e, _ = reflect.NewWithExchanger(rc.Name, opts.Logger, e)
 

--- a/pkg/resolver/filter.go
+++ b/pkg/resolver/filter.go
@@ -1,0 +1,65 @@
+package resolver
+
+import (
+	"context"
+
+	"darvaza.org/core"
+	"darvaza.org/resolver"
+	"darvaza.org/resolver/pkg/exdns"
+	"github.com/miekg/dns"
+)
+
+func newOmitEDNS0SubNetExchanger(next resolver.Exchanger) resolver.Exchanger {
+	fn := func(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+		return omitEDNS0SubNetExchange(ctx, req, next)
+	}
+
+	return resolver.ExchangerFunc(fn)
+}
+
+func omitEDNS0SubNetExchange(ctx context.Context, req *dns.Msg, next resolver.Exchanger) (*dns.Msg, error) {
+	var original = req
+
+	req2 := req.Copy()
+	if removeEDNS0SUBNET(req2) {
+		req2.Id = dns.Id()
+		req = req2
+	}
+
+	resp, err := next.Exchange(ctx, req)
+	return exdns.RestoreReturn(original, resp, err)
+}
+
+func removeEDNS0SUBNET(req *dns.Msg) bool {
+	var altered bool
+
+	filterEDNS0 := func(_ []dns.EDNS0, e dns.EDNS0) (dns.EDNS0, bool) {
+		if e.Option() == dns.EDNS0SUBNET {
+			// discard
+			altered = true
+			return nil, false
+		}
+
+		// keep
+		return e, true
+	}
+
+	filterRR := func(_ []dns.RR, rr dns.RR) (dns.RR, bool) {
+		if opts, ok := rr.(*dns.OPT); ok {
+			// remove EDNS0SUBNET options
+			opts.Option = core.SliceReplaceFn(opts.Option, filterEDNS0)
+
+			if len(opts.Option) == 0 {
+				// empty RR, discard
+				altered = true
+				return nil, false
+			}
+		}
+
+		// keep
+		return rr, true
+	}
+
+	req.Extra = core.SliceReplaceFn(req.Extra, filterRR)
+	return altered
+}

--- a/pkg/server/server_horizon.go
+++ b/pkg/server/server_horizon.go
@@ -20,12 +20,13 @@ func defaultHorizons() []horizon.Config {
 
 func (srv *Server) initHorizons() error {
 	// prepare srv.z
-	srv.z.ContextKey = horizon.NewContextKey("penne.horizon.match")
+	ctxKey := horizon.NewContextKey("penne.horizon.match")
+	srv.z.ContextKey = ctxKey
 	srv.z.ExchangeTimeout = srv.cfg.ExchangeTimeout
 	srv.z.ExchangeContext = reflect.WithEnabledFunc(srv.cfg.Context, srv.reflectEnabled)
 
 	// build horizons
-	names, m, err := horizon.MakeHorizons(srv.cfg.Horizons, srv.res)
+	names, m, err := horizon.MakeHorizons(srv.cfg.Horizons, srv.res, ctxKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server_horizon.go
+++ b/pkg/server/server_horizon.go
@@ -25,7 +25,7 @@ func (srv *Server) initHorizons() error {
 	srv.z.ExchangeContext = reflect.WithEnabledFunc(srv.cfg.Context, srv.reflectEnabled)
 
 	// build horizons
-	names, m, err := horizon.MakeHorizons(srv.cfg.Horizons, nil)
+	names, m, err := horizon.MakeHorizons(srv.cfg.Horizons, srv.res)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
and inject a new EDNS0_SUBNET based on the Horizon.Match

We probably want to add a flag on iterative and forwarder resolvers to remove it before connecting to the remote servers.