### PR TITLE
github: test under Go 1.22 too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.21' ]
+        go: [ '1.21', '1.22' ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI/CD workflow to support testing and building with Go version 1.22 alongside 1.21, enhancing compatibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->